### PR TITLE
feat(sim): add season-wide simulation and league table; add round arg

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+exclude = .git, __pycache__, .venv, venv, build, dist, .mypy_cache, .pytest_cache

--- a/app/db.py
+++ b/app/db.py
@@ -1,11 +1,27 @@
 import sqlite3
 from pathlib import Path
 
+
 def connect(db_path: str = "football.db") -> sqlite3.Connection:
     con = sqlite3.connect(db_path)
     con.execute("PRAGMA foreign_keys = ON;")
     return con
 
+
 def apply_schema(con: sqlite3.Connection, schema_path: str = "sql/schema.sql") -> None:
     sql = Path(schema_path).read_text(encoding="utf-8")
     con.executescript(sql)
+
+
+def ensure_fixture_goal_columns(con: sqlite3.Connection) -> None:
+    # 既存カラムを確認
+    cols = {row[1] for row in con.execute("PRAGMA table_info(fixtures)")}
+    to_add = []
+    if "home_goals" not in cols:
+        to_add.append(("home_goals", "INTEGER"))
+    if "away_goals" not in cols:
+        to_add.append(("away_goals", "INTEGER"))
+    if to_add:
+        for name, typ in to_add:
+            con.execute(f"ALTER TABLE fixtures ADD COLUMN {name} {typ}")
+    con.commit()

--- a/app/schedule.py
+++ b/app/schedule.py
@@ -6,6 +6,7 @@ Match = Tuple[str, str]
 Round = List[Match]
 Schedule = List[Round]
 
+
 def generate_round_robin(
     teams: List[str],
     double_round: bool = True,
@@ -22,14 +23,15 @@ def generate_round_robin(
     if len(teams) % 2 == 1:
         teams.append(bye_token)
 
-    n = len(teams); half = n // 2
+    n = len(teams)
+    half = n // 2
     fixed, rot = teams[0], teams[1:]
 
     rounds: Schedule = []
     for r in range(n - 1):
-        left = [fixed] + rot[:half - 1]
-        right = rot[half - 1:][::-1]
-        swap = (r % 2 == 1)
+        left = [fixed] + rot[: half - 1]
+        right = rot[half - 1 :][::-1]
+        swap = r % 2 == 1
         matches: Round = []
         for a, b in zip(left, right):
             if bye_token in (a, b):
@@ -41,6 +43,7 @@ def generate_round_robin(
     if double_round:
         rounds += [[(b, a) for (a, b) in rnd] for rnd in rounds]
     return rounds
+
 
 def assign_dates(schedule: Schedule, start_on: date, interval_days: int = 7):
     out = []

--- a/app/sim.py
+++ b/app/sim.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+import math
+import random
+from typing import Tuple
+
+
+@dataclass
+class TeamStrength:
+    attack: float  # 攻撃強度（平均0を想定）
+    defense: float  # 守備強度（平均0を想定・値が高いほど強い）
+
+
+def expected_goals(
+    home: TeamStrength, away: TeamStrength, base: float = 1.25, home_adv: float = 0.12
+) -> Tuple[float, float]:
+    """
+    期待得点λの設計：
+    λ_home = base * exp( (A_home - D_away) + home_adv )
+    λ_away = base * exp( (A_away - D_home) )
+    """
+    lam_h = base * math.exp((home.attack - away.defense) + home_adv)
+    lam_a = base * math.exp((away.attack - home.defense))
+    return lam_h, lam_a
+
+
+def poisson_sample(lam: float, rng: random.Random) -> int:
+    """
+    追加依存を増やさず Knuth法でPoisson乱数を生成
+    """
+    L = math.exp(-lam)
+    k = 0
+    p = 1.0
+    while True:
+        k += 1
+        p *= rng.random()
+        if p <= L:
+            return k - 1
+
+
+def simulate_score(
+    lam_h: float, lam_a: float, seed: int | None = None
+) -> Tuple[int, int]:
+    rng = random.Random(seed)
+    return poisson_sample(lam_h, rng), poisson_sample(lam_a, rng)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/scripts/setup_schedule.py
+++ b/scripts/setup_schedule.py
@@ -8,9 +8,11 @@ START_ON = date(2025, 9, 20)
 INTERVAL_DAYS = 7
 DB_PATH = "football.db"
 
+
 def load_teams_csv(path="data/teams.csv"):
     with open(path, newline="", encoding="utf-8") as f:
         return [row["name"] for row in csv.DictReader(f)]
+
 
 def main():
     teams = load_teams_csv()
@@ -20,26 +22,32 @@ def main():
         apply_schema(con)
         with con:
             con.executemany(
-                "INSERT OR IGNORE INTO teams(name) VALUES(?)",
-                [(t,) for t in teams]
+                "INSERT OR IGNORE INTO teams(name) VALUES(?)", [(t,) for t in teams]
             )
 
         schedule = generate_round_robin(
             teams, double_round=True, shuffle_teams=True, seed=123
         )
-        fixtures = assign_dates(schedule, start_on=START_ON, interval_days=INTERVAL_DAYS)
+        fixtures = assign_dates(
+            schedule, start_on=START_ON, interval_days=INTERVAL_DAYS
+        )
 
         # name→id
         cur = con.execute("SELECT id, name FROM teams")
         name_id = {n: i for i, n in cur.fetchall()}
 
-        rows = [(SEASON, rnd, d.isoformat(), name_id[h], name_id[a]) for rnd, d, h, a in fixtures]
+        rows = [
+            (SEASON, rnd, d.isoformat(), name_id[h], name_id[a])
+            for rnd, d, h, a in fixtures
+        ]
+
+        sql = (
+            "INSERT OR IGNORE INTO fixtures("
+            "season, round_no, match_date, home_team_id, away_team_id"
+            ") VALUES (?, ?, ?, ?, ?)"
+        )
         with con:
-            con.executemany(
-                "INSERT OR IGNORE INTO fixtures(season, round_no, match_date, home_team_id, away_team_id) "
-                "VALUES (?, ?, ?, ?, ?)",
-                rows
-            )
+            con.executemany(sql, rows)
 
         # 動作確認
         for row in con.execute(
@@ -49,11 +57,13 @@ def main():
             JOIN teams th ON th.id=f.home_team_id
             JOIN teams ta ON ta.id=f.away_team_id
             WHERE season=? ORDER BY round_no, f.id LIMIT 10
-            """, (SEASON,)
+            """,
+            (SEASON,),
         ):
             print(row)
     finally:
         con.close()
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/show_table.py
+++ b/scripts/show_table.py
@@ -1,14 +1,15 @@
 # scripts/show_table.py
 import sqlite3
-import sys
 
 SEASON = 2025
 DB_PATH = "football.db"
 
+
 def main():
     con = sqlite3.connect(DB_PATH)
     try:
-        cur = con.execute("""
+        cur = con.execute(
+            """
         WITH played AS (
           SELECT * FROM fixtures
           WHERE season=? AND status='played'
@@ -54,13 +55,19 @@ def main():
         FROM allrows
         GROUP BY team_id
         ORDER BY Pts DESC, GD DESC, GF DESC, name ASC;
-        """, (SEASON,))
+        """,
+            (SEASON,),
+        )
         print("Team                     Pld  W  D  L  GF  GA  GD  Pts")
-        print("-"*62)
-        for (name, pld, w, d, l, gf, ga, gd, pts) in cur.fetchall():
-            print(f"{name:22} {pld:>3} {w:>2} {d:>2} {l:>2} {gf:>3} {ga:>3} {gd:>3} {pts:>4}")
+        print("-" * 62)
+        for name, pld, w, d, l, gf, ga, gd, pts in cur.fetchall():
+            print(
+                f"{name:22} {pld:>3} {w:>2} {d:>2} {l:>2} "
+                f"{gf:>3} {ga:>3} {gd:>3} {pts:>4}"
+            )
     finally:
         con.close()
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/show_table.py
+++ b/scripts/show_table.py
@@ -1,0 +1,66 @@
+# scripts/show_table.py
+import sqlite3
+import sys
+
+SEASON = 2025
+DB_PATH = "football.db"
+
+def main():
+    con = sqlite3.connect(DB_PATH)
+    try:
+        cur = con.execute("""
+        WITH played AS (
+          SELECT * FROM fixtures
+          WHERE season=? AND status='played'
+        ),
+        home AS (
+          SELECT th.id AS team_id, th.name,
+                 1 AS pld,
+                 CASE WHEN f.home_goals > f.away_goals THEN 1 ELSE 0 END AS w,
+                 CASE WHEN f.home_goals = f.away_goals THEN 1 ELSE 0 END AS d,
+                 CASE WHEN f.home_goals < f.away_goals THEN 1 ELSE 0 END AS l,
+                 f.home_goals AS gf, f.away_goals AS ga,
+                 CASE WHEN f.home_goals > f.away_goals THEN 3
+                      WHEN f.home_goals = f.away_goals THEN 1 ELSE 0 END AS pts
+          FROM played f
+          JOIN teams th ON th.id=f.home_team_id
+        ),
+        away AS (
+          SELECT ta.id AS team_id, ta.name,
+                 1 AS pld,
+                 CASE WHEN f.away_goals > f.home_goals THEN 1 ELSE 0 END AS w,
+                 CASE WHEN f.away_goals = f.home_goals THEN 1 ELSE 0 END AS d,
+                 CASE WHEN f.away_goals < f.home_goals THEN 1 ELSE 0 END AS l,
+                 f.away_goals AS gf, f.home_goals AS ga,
+                 CASE WHEN f.away_goals > f.home_goals THEN 3
+                      WHEN f.away_goals = f.home_goals THEN 1 ELSE 0 END AS pts
+          FROM played f
+          JOIN teams ta ON ta.id=f.away_team_id
+        ),
+        allrows AS (
+          SELECT * FROM home
+          UNION ALL
+          SELECT * FROM away
+        )
+        SELECT name,
+               SUM(pld) AS Pld,
+               SUM(w) AS W,
+               SUM(d) AS D,
+               SUM(l) AS L,
+               SUM(gf) AS GF,
+               SUM(ga) AS GA,
+               SUM(gf) - SUM(ga) AS GD,
+               SUM(pts) AS Pts
+        FROM allrows
+        GROUP BY team_id
+        ORDER BY Pts DESC, GD DESC, GF DESC, name ASC;
+        """, (SEASON,))
+        print("Team                     Pld  W  D  L  GF  GA  GD  Pts")
+        print("-"*62)
+        for (name, pld, w, d, l, gf, ga, gd, pts) in cur.fetchall():
+            print(f"{name:22} {pld:>3} {w:>2} {d:>2} {l:>2} {gf:>3} {ga:>3} {gd:>3} {pts:>4}")
+    finally:
+        con.close()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sim_all.py
+++ b/scripts/sim_all.py
@@ -7,10 +7,14 @@ SEASON = 2025
 DB_PATH = "football.db"
 SEED_BASE = 54321
 
+
 def fetch_team_strengths(con: sqlite3.Connection) -> dict[int, TeamStrength]:
     rows = con.execute("SELECT id, rating_attack, rating_defense FROM teams").fetchall()
-    return {tid: TeamStrength(attack=att or 0.0, defense=defn or 0.0)
-            for (tid, att, defn) in rows}
+    return {
+        tid: TeamStrength(attack=att or 0.0, defense=defn or 0.0)
+        for (tid, att, defn) in rows
+    }
+
 
 def main():
     con = connect(DB_PATH)
@@ -19,12 +23,15 @@ def main():
         ensure_fixture_goal_columns(con)
         strengths = fetch_team_strengths(con)
 
-        rows = con.execute("""
+        rows = con.execute(
+            """
             SELECT id, round_no, home_team_id, away_team_id
             FROM fixtures
             WHERE season=? AND status='scheduled'
             ORDER BY round_no, id
-        """, (SEASON,)).fetchall()
+        """,
+            (SEASON,),
+        ).fetchall()
 
         if not rows:
             print("No scheduled fixtures. Nothing to simulate.")
@@ -40,11 +47,12 @@ def main():
         with con:
             con.executemany(
                 "UPDATE fixtures SET home_goals=?, away_goals=?, status=? WHERE id=?",
-                updates
+                updates,
             )
         print(f"Saved {len(updates)} results.")
     finally:
         con.close()
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/sim_all.py
+++ b/scripts/sim_all.py
@@ -1,0 +1,50 @@
+# scripts/sim_all.py
+import sqlite3
+from app.db import connect, apply_schema, ensure_fixture_goal_columns
+from app.sim import TeamStrength, expected_goals, simulate_score
+
+SEASON = 2025
+DB_PATH = "football.db"
+SEED_BASE = 54321
+
+def fetch_team_strengths(con: sqlite3.Connection) -> dict[int, TeamStrength]:
+    rows = con.execute("SELECT id, rating_attack, rating_defense FROM teams").fetchall()
+    return {tid: TeamStrength(attack=att or 0.0, defense=defn or 0.0)
+            for (tid, att, defn) in rows}
+
+def main():
+    con = connect(DB_PATH)
+    try:
+        apply_schema(con)
+        ensure_fixture_goal_columns(con)
+        strengths = fetch_team_strengths(con)
+
+        rows = con.execute("""
+            SELECT id, round_no, home_team_id, away_team_id
+            FROM fixtures
+            WHERE season=? AND status='scheduled'
+            ORDER BY round_no, id
+        """, (SEASON,)).fetchall()
+
+        if not rows:
+            print("No scheduled fixtures. Nothing to simulate.")
+            return
+
+        updates = []
+        for i, (fix_id, rnd, home_id, away_id) in enumerate(rows, start=1):
+            lam_h, lam_a = expected_goals(strengths[home_id], strengths[away_id])
+            hg, ag = simulate_score(lam_h, lam_a, seed=SEED_BASE + i)
+            print(f"[R{rnd}] fixture#{fix_id} {home_id} vs {away_id} -> {hg}-{ag}")
+            updates.append((hg, ag, "played", fix_id))
+
+        with con:
+            con.executemany(
+                "UPDATE fixtures SET home_goals=?, away_goals=?, status=? WHERE id=?",
+                updates
+            )
+        print(f"Saved {len(updates)} results.")
+    finally:
+        con.close()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sim_round.py
+++ b/scripts/sim_round.py
@@ -1,7 +1,11 @@
 # scripts/sim_round.py
 import sys
 import sqlite3
-from app.db import connect, apply_schema, ensure_fixture_goal_columns  # ← ensure_schema ではなく apply_schema
+from app.db import (
+    connect,
+    apply_schema,
+    ensure_fixture_goal_columns,
+)  # ← ensure_schema ではなく apply_schema
 from app.sim import TeamStrength, expected_goals, simulate_score
 
 SEASON = 2025
@@ -9,24 +13,31 @@ ROUND = int(sys.argv[1]) if len(sys.argv) > 1 else 1  # ← ここを引数対�
 SEED_BASE = 12345
 DB_PATH = "football.db"
 
+
 def fetch_team_strengths(con: sqlite3.Connection) -> dict[int, TeamStrength]:
     rows = con.execute("SELECT id, rating_attack, rating_defense FROM teams").fetchall()
-    return {tid: TeamStrength(attack=att or 0.0, defense=defn or 0.0)
-            for (tid, att, defn) in rows}
+    return {
+        tid: TeamStrength(attack=att or 0.0, defense=defn or 0.0)
+        for (tid, att, defn) in rows
+    }
+
 
 def main():
     con = connect(DB_PATH)
     try:
-        apply_schema(con)                 # ← ここも ensure_schema ではなく apply_schema
+        apply_schema(con)  # ← ここも ensure_schema ではなく apply_schema
         ensure_fixture_goal_columns(con)
 
         strengths = fetch_team_strengths(con)
-        rows = con.execute("""
+        rows = con.execute(
+            """
             SELECT id, home_team_id, away_team_id
             FROM fixtures
             WHERE season=? AND round_no=? AND status='scheduled'
             ORDER BY id
-        """, (SEASON, ROUND)).fetchall()
+        """,
+            (SEASON, ROUND),
+        ).fetchall()
 
         if not rows:
             print(f"No scheduled fixtures for season={SEASON}, round={ROUND}.")
@@ -36,17 +47,21 @@ def main():
         for i, (fix_id, home_id, away_id) in enumerate(rows, start=1):
             lam_h, lam_a = expected_goals(strengths[home_id], strengths[away_id])
             hg, ag = simulate_score(lam_h, lam_a, seed=SEED_BASE + i)
-            print(f"[R{ROUND}] fixture#{fix_id} {home_id} vs {away_id} -> {hg}-{ag} (λ={lam_h:.2f}/{lam_a:.2f})")
+            print(
+                f"[R{ROUND}] fixture#{fix_id} {home_id} vs {away_id} -> "
+                f"{hg}-{ag} (λ={lam_h:.2f}/{lam_a:.2f})"
+            )
             updates.append((hg, ag, "played", fix_id))
 
         with con:
             con.executemany(
                 "UPDATE fixtures SET home_goals=?, away_goals=?, status=? WHERE id=?",
-                updates
+                updates,
             )
         print("Saved results.")
     finally:
         con.close()
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/sim_round.py
+++ b/scripts/sim_round.py
@@ -1,0 +1,52 @@
+# scripts/sim_round.py
+import sys
+import sqlite3
+from app.db import connect, apply_schema, ensure_fixture_goal_columns  # ← ensure_schema ではなく apply_schema
+from app.sim import TeamStrength, expected_goals, simulate_score
+
+SEASON = 2025
+ROUND = int(sys.argv[1]) if len(sys.argv) > 1 else 1  # ← ここを引数対応に
+SEED_BASE = 12345
+DB_PATH = "football.db"
+
+def fetch_team_strengths(con: sqlite3.Connection) -> dict[int, TeamStrength]:
+    rows = con.execute("SELECT id, rating_attack, rating_defense FROM teams").fetchall()
+    return {tid: TeamStrength(attack=att or 0.0, defense=defn or 0.0)
+            for (tid, att, defn) in rows}
+
+def main():
+    con = connect(DB_PATH)
+    try:
+        apply_schema(con)                 # ← ここも ensure_schema ではなく apply_schema
+        ensure_fixture_goal_columns(con)
+
+        strengths = fetch_team_strengths(con)
+        rows = con.execute("""
+            SELECT id, home_team_id, away_team_id
+            FROM fixtures
+            WHERE season=? AND round_no=? AND status='scheduled'
+            ORDER BY id
+        """, (SEASON, ROUND)).fetchall()
+
+        if not rows:
+            print(f"No scheduled fixtures for season={SEASON}, round={ROUND}.")
+            return
+
+        updates = []
+        for i, (fix_id, home_id, away_id) in enumerate(rows, start=1):
+            lam_h, lam_a = expected_goals(strengths[home_id], strengths[away_id])
+            hg, ag = simulate_score(lam_h, lam_a, seed=SEED_BASE + i)
+            print(f"[R{ROUND}] fixture#{fix_id} {home_id} vs {away_id} -> {hg}-{ag} (λ={lam_h:.2f}/{lam_a:.2f})")
+            updates.append((hg, ag, "played", fix_id))
+
+        with con:
+            con.executemany(
+                "UPDATE fixtures SET home_goals=?, away_goals=?, status=? WHERE id=?",
+                updates
+            )
+        print("Saved results.")
+    finally:
+        con.close()
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,8 +1,11 @@
 from app.schedule import generate_round_robin
 
+
 def test_round_count_even_teams():
     teams = [f"T{i}" for i in range(6)]
-    sched = generate_round_robin(teams, double_round=True, shuffle_teams=False, seed=None)
+    sched = generate_round_robin(
+        teams, double_round=True, shuffle_teams=False, seed=None
+    )
     # 6チーム → 1回戦で5節、2回戦で10節
     assert len(sched) == 10
     # 各節、3試合（重複なし）


### PR DESCRIPTION
目的
- シーズン全試合の一括シミュレーションを追加
- 順位表出力のスクリプトを追加
- sim_round に引数（節）対応

変更点
- scripts/sim_all.py 追加
- scripts/show_table.py 追加
- scripts/sim_round.py 引数対応

テスト
- python -m scripts.sim_round 1 実行
- python -m scripts.sim_all 実行
- python -m scripts.show_table で順位表が表示されることを確認
